### PR TITLE
Add compare options and allow them to be attached to objects.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,10 @@ Authors@R:
              role = c("aut", "cre"),
              email = "hadley@rstudio.com"),
       person(given = "RStudio",
-             role = "cph"))
+             role = "cph"),
+      person(given = "Duncan",
+             family = "Murdoch",
+             role = "ctb"))
 Description: Compare complex R objects and reveal the key
     differences.  Designed particularly for use in testing packages where
     being able to quickly isolate key differences makes understanding test
@@ -21,6 +24,7 @@ Imports:
     fansi,
     glue,
     methods,
+    purrr,
     rematch2,
     rlang (>= 0.4.10),
     tibble

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,6 @@ Imports:
     fansi,
     glue,
     methods,
-    purrr,
     rematch2,
     rlang (>= 0.4.10),
     tibble

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # waldo (development version)
 
+* Compare options `ignore_name_order`, `ignore_NULLs`, and
+  `ignore_private` have been added.
+* Compare options may be specified in the `"waldo_opts"` 
+  attribute of the objects being compared.
+  
 # waldo 0.2.5
 
 * On platforms without UTF-8 support, strings that differ only in their

--- a/R/compare-opts.R
+++ b/R/compare-opts.R
@@ -5,7 +5,8 @@ compare_opts <- function(...,
                          ignore_attr = FALSE,
                          ignore_encoding = TRUE,
                          ignore_formula_env = FALSE,
-                         ignore_function_env = FALSE
+                         ignore_function_env = FALSE,
+                         priority = 0
                          ) {
 
   base <- old_opts(...)
@@ -17,7 +18,8 @@ compare_opts <- function(...,
     ignore_attr = ignore_attr,
     ignore_encoding = ignore_encoding,
     ignore_formula_env = ignore_formula_env,
-    ignore_function_env = ignore_function_env
+    ignore_function_env = ignore_function_env,
+    priority = priority
   )
 
   utils::modifyList(waldo, base)
@@ -51,4 +53,18 @@ old_opts <- function(..., tol, check.attributes, checkNames) {
   }
 
   out
+}
+
+object_opts <- function(x, default_priority) {
+  result <- attr(x, "waldo_opts")
+  if (!is.null(result) && is.null(result$priority))
+    result$priority <- default_priority
+  result
+}
+
+merge_opts <- function(...) {
+  allopts <- zap_nulls(list(...))
+  priorities <- purrr::map_dbl(allopts, "priority")
+  o <- order(priorities)
+  purrr::reduce(allopts[o], utils::modifyList)
 }

--- a/R/compare-opts.R
+++ b/R/compare-opts.R
@@ -2,11 +2,13 @@ compare_opts <- function(...,
                          tolerance = NULL,
                          max_diffs = if (in_ci()) Inf else 10,
                          ignore_srcref = TRUE,
-                         ignore_attr = FALSE,
+                         ignore_attr = "waldo_opts",
                          ignore_encoding = TRUE,
-                         ignore_formula_env = FALSE,
                          ignore_function_env = FALSE,
-                         priority = 0
+                         ignore_formula_env = FALSE,
+                         ignore_name_order = FALSE,
+                         ignore_NULLs = FALSE,
+                         ignore_private = character()
                          ) {
 
   base <- old_opts(...)
@@ -19,7 +21,9 @@ compare_opts <- function(...,
     ignore_encoding = ignore_encoding,
     ignore_formula_env = ignore_formula_env,
     ignore_function_env = ignore_function_env,
-    priority = priority
+    ignore_name_order = ignore_name_order,
+    ignore_NULLs = ignore_NULLs,
+    ignore_private = ignore_private
   )
 
   utils::modifyList(waldo, base)
@@ -55,16 +59,11 @@ old_opts <- function(..., tol, check.attributes, checkNames) {
   out
 }
 
-object_opts <- function(x, default_priority) {
-  result <- attr(x, "waldo_opts")
-  if (!is.null(result) && is.null(result$priority))
-    result$priority <- default_priority
-  result
+object_opts <- function(x) {
+  attr(x, "waldo_opts")
 }
 
 merge_opts <- function(...) {
   allopts <- zap_nulls(list(...))
-  priorities <- purrr::map_dbl(allopts, "priority")
-  o <- order(priorities)
-  purrr::reduce(allopts[o], utils::modifyList)
+  purrr::reduce(allopts, utils::modifyList)
 }

--- a/R/compare-opts.R
+++ b/R/compare-opts.R
@@ -64,6 +64,6 @@ object_opts <- function(x) {
 }
 
 merge_opts <- function(...) {
-  allopts <- zap_nulls(list(...))
-  purrr::reduce(allopts, utils::modifyList)
+  allopts <- compact(list(...))
+  Reduce(utils::modifyList, allopts, init = list())
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -103,3 +103,8 @@ split_by_line <- function(x) {
 multiline <- function(x) any(grepl("\n", x))
 
 default_tol <- function() .Machine$double.eps^0.5
+
+compact <- function(x) {
+  is_null <- vapply(x, is.null, logical(1))
+  x[!is_null]
+}

--- a/man/compare.Rd
+++ b/man/compare.Rd
@@ -82,8 +82,8 @@ lists or vectors.}
 \item{ignore_NULLs}{In lists and pairlists, ignore elements that are set to
 \code{NULL}.}
 
-\item{ignore_private}{Components named in this vector are completely ignored
-in comparisons.}
+\item{ignore_private}{Components matching the patterns in this vector are
+completely ignored in comparisons.  See Details below.}
 }
 \value{
 A character vector with class "waldo_compare". If there are no
@@ -120,6 +120,12 @@ highest precedence:
 \item User-specified arguments to \code{compare()} override
 everything else.
 }
+
+The patterns listed in the \code{ignore_private} vector are
+regular expressions applied to the "paths" to components.
+For example, \code{ignore_private = "\\\\$_"} will cause components
+with names starting with \code{"_"} to be ignored, since
+paths like \verb{old$_component} will match that pattern.
 }
 \examples{
 # Thanks to diffobj package comparison of atomic vectors shows differences

--- a/man/compare.Rd
+++ b/man/compare.Rd
@@ -13,10 +13,13 @@ compare(
   tolerance = NULL,
   max_diffs = if (in_ci()) Inf else 10,
   ignore_srcref = TRUE,
-  ignore_attr = FALSE,
+  ignore_attr = "waldo_opts",
   ignore_encoding = TRUE,
   ignore_function_env = FALSE,
-  ignore_formula_env = FALSE
+  ignore_formula_env = FALSE,
+  ignore_name_order = FALSE,
+  ignore_NULLs = FALSE,
+  ignore_private = character()
 )
 }
 \arguments{
@@ -72,6 +75,15 @@ with the encoding, not just the value of the string.}
 functions and formulas, respectively? These are provided primarily for
 backward compatibility with \code{all.equal()} which always ignores these
 environments.}
+
+\item{ignore_name_order}{Ignore changes to the order of named components in
+lists or vectors.}
+
+\item{ignore_NULLs}{In lists and pairlists, ignore elements that are set to
+\code{NULL}.}
+
+\item{ignore_private}{Components named in this vector are completely ignored
+in comparisons.}
 }
 \value{
 A character vector with class "waldo_compare". If there are no
@@ -92,6 +104,23 @@ when colour isn't available).
 
 \code{compare()} is an alternative to \code{\link[=all.equal]{all.equal()}}.
 }
+\details{
+Objects may contain an attribute named \code{"waldo_opts"}, which should
+be a list containing compare options.  If \code{x} or \code{y} has its own
+components, each of those may contain a \code{"waldo_opts"} attribute.  If
+present the options will be applied in the following order from lowest to
+highest precedence:
+\enumerate{
+\item Defaults from this function.
+\item The \code{waldo_opts} for \code{x}.
+\item The \code{waldo_opts} for \code{y}.
+\item The \code{waldo_opts} for components of \code{x}.
+\item The \code{waldo_opts} for corresponding components of \code{y}.
+\item Continue recursively...
+\item User-specified arguments to \code{compare()} override
+everything else.
+}
+}
 \examples{
 # Thanks to diffobj package comparison of atomic vectors shows differences
 # with a little context
@@ -111,7 +140,19 @@ compare(
 compare(iris, rev(iris))
 
 compare(list(x = "x", y = "y"), list(y = "y", x = "x"))
+
 # Otherwise they're compared by position
 compare(list("x", "y"), list("x", "z"))
 compare(list(x = "x", x = "y"), list(x = "x", y = "z"))
+
+# Compare options can be attached to the objects themselves:
+compare(list(x = "x", y = "y"),
+        structure(list(y = "y", x = "x"),
+                  waldo_opts = list(ignore_name_order = TRUE)))
+
+# User choices have top priority:
+compare(list(x = "x", y = "y"),
+        structure(list(y = "y", x = "x"),
+                  waldo_opts = list(ignore_name_order = TRUE)),
+        ignore_name_order = FALSE)
 }

--- a/man/compare.Rd
+++ b/man/compare.Rd
@@ -83,7 +83,7 @@ lists or vectors.}
 \code{NULL}.}
 
 \item{ignore_private}{Components matching the patterns in this vector are
-completely ignored in comparisons.  See Details below.}
+completely ignored in comparisons.}
 }
 \value{
 A character vector with class "waldo_compare". If there are no
@@ -120,6 +120,11 @@ highest precedence:
 \item User-specified arguments to \code{compare()} override
 everything else.
 }
+
+By default the \code{"waldo_opts"} attribute is listed in
+\code{ignore_attr} so that changes to it are not reported; if you
+customize \code{ignore_attr}, you will probably want to do this
+yourself.
 
 The patterns listed in the \code{ignore_private} vector are
 regular expressions applied to the "paths" to components.

--- a/man/waldo-package.Rd
+++ b/man/waldo-package.Rd
@@ -25,6 +25,7 @@ Useful links:
 Other contributors:
 \itemize{
   \item RStudio [copyright holder]
+  \item Duncan Murdoch [contributor]
 }
 
 }

--- a/tests/testthat/test-compare-options.txt
+++ b/tests/testthat/test-compare-options.txt
@@ -1,18 +1,26 @@
-> x <- list(a = 1, b = 2)
-> y <- list(a = 1, b = 2, c = NULL)
+> x <- list(a = 1, b = 2, c = 3, d = list(e = 1, f = NULL))
+> y <- list(a = 1, b = 2, c = 4, d = list(e = 1, f = 1))
 > compare(x, y)
-`old` is length 2
-`new` is length 3
+`old$c`: 3
+`new$c`: 4
 
-`names(old)`: "a" "b"    
-`names(new)`: "a" "b" "c"
-
-`old$c` is absent
-`new$c` is NULL
+`old$d$f` is NULL
+`new$d$f` is a double vector (1)
 
 > compare(x, y, ignore_NULLs = TRUE)
-v No differences
+`old$c`: 3
+`new$c`: 4
 
-> compare(x, y, ignore_private = "c")
-v No differences
+`old$d` is length 1
+`new$d` is length 2
+
+`names(old$d)`: "e"    
+`names(new$d)`: "e" "f"
+
+`old$d$f` is absent
+`new$d$f` is a double vector (1)
+
+> compare(x, y, ignore_private = "d\\$f")
+`old$c`: 3
+`new$c`: 4
 

--- a/tests/testthat/test-compare-options.txt
+++ b/tests/testthat/test-compare-options.txt
@@ -1,0 +1,18 @@
+> x <- list(a = 1, b = 2)
+> y <- list(a = 1, b = 2, c = NULL)
+> compare(x, y)
+`old` is length 2
+`new` is length 3
+
+`names(old)`: "a" "b"    
+`names(new)`: "a" "b" "c"
+
+`old$c` is absent
+`new$c` is NULL
+
+> compare(x, y, ignore_NULLs = TRUE)
+v No differences
+
+> compare(x, y, ignore_private = "c")
+v No differences
+

--- a/tests/testthat/test-compare-priority.txt
+++ b/tests/testthat/test-compare-priority.txt
@@ -1,0 +1,27 @@
+> x <- list(a = 1, b = 2)
+> y <- rev(x)
+> attr(x, "waldo_opts") <- list(ignore_name_order = TRUE)
+> attr(y, "waldo_opts") <- list(ignore_name_order = FALSE)
+> compare(x, y)
+`names(old)`: "a" "b"    
+`names(new)`:     "b" "a"
+
+> compare(y, x)
+v No differences
+
+> compare(x, y, ignore_name_order = TRUE)
+v No differences
+
+> x$z <- structure(list(c = 3, d = 4), waldo_opts = list(ignore_name_order = FALSE))
+> y$z <- rev(x$z)
+> compare(x, y)
+`names(old)`: "a" "b"     "z"
+`names(new)`:     "b" "a" "z"
+
+`names(old$z)`: "c" "d"    
+`names(new$z)`:     "d" "c"
+
+> compare(y, x)
+`names(old$z)`: "d" "c"    
+`names(new$z)`:     "c" "d"
+

--- a/tests/testthat/test-compare.R
+++ b/tests/testthat/test-compare.R
@@ -235,3 +235,30 @@ test_that("comparing language objects gives useful diffs", {
     compare(expression(1, a, a + b), expression(1, a, a + c))
   })
 })
+
+test_that("compare options have correct precedence", {
+  verify_output(test_path("test-compare-priority.txt"), {
+    x <- list(a = 1, b = 2)
+    y <- rev(x)
+    attr(x, "waldo_opts") <- list(ignore_name_order = TRUE)
+    attr(y, "waldo_opts") <- list(ignore_name_order = FALSE)
+    compare(x, y)
+    compare(y, x)
+    compare(x, y, ignore_name_order = TRUE)
+    x$z <- structure(list(c = 3, d = 4),
+                     waldo_opts = list(ignore_name_order = FALSE))
+    y$z <- rev(x$z)
+    compare(x, y)
+    compare(y, x)
+  })
+})
+
+test_that("new compare options work", {
+  verify_output(test_path("test-compare-options.txt"), {
+    x <- list(a = 1, b = 2)
+    y <- list(a = 1, b = 2, c = NULL)
+    compare(x, y)
+    compare(x, y, ignore_NULLs = TRUE)
+    compare(x, y, ignore_private = "c")
+  })
+})

--- a/tests/testthat/test-compare.R
+++ b/tests/testthat/test-compare.R
@@ -255,10 +255,10 @@ test_that("compare options have correct precedence", {
 
 test_that("new compare options work", {
   verify_output(test_path("test-compare-options.txt"), {
-    x <- list(a = 1, b = 2)
-    y <- list(a = 1, b = 2, c = NULL)
+    x <- list(a = 1, b = 2, c = 3, d = list(e = 1, f = NULL))
+    y <- list(a = 1, b = 2, c = 4, d = list(e = 1, f = 1))
     compare(x, y)
     compare(x, y, ignore_NULLs = TRUE)
-    compare(x, y, ignore_private = "c")
+    compare(x, y, ignore_private = "d\\$f")
   })
 })


### PR DESCRIPTION
This is intended to fix #72, though there are some issues for discussion.

It adds options to `compare()` so it can ignore the order of names, ignore `NULL` elements in lists, or ignore specifically named components of lists.

The options can be attached as attributes to `x` or `y`, rather than being specified in the `compare(x, y)` call.

Some issues:

 - If the same option is specified in more than one place, what happens?  I chose to let one spec override earlier ones.  They are applied in the order:  defaults to `compare()`, options on `x`, options on `y`, user-specified arguments to `compare()`.  If `x` and `y` are lists, each component can change the options; the more specific one wins (just like CSS). You might want to change some of that. - 
- The `ignore_private = character()` option ignores components by name.  Because of the inheritance, this is kind of weird in nested structures:  maybe I'd just want to ignore `private` at one level but not others.  I can do this, but it's cumbersome.  Or maybe I'd like to specify a pattern for private components, instead of listing them all by name.