### PR TITLE
Use identical() for fast path

### DIFF
--- a/R/compare.R
+++ b/R/compare.R
@@ -109,7 +109,7 @@ compare <- function(x, y, ...,
 
 
 compare_structure <- function(x, y, paths = c("x", "y"), opts = compare_opts()) {
-  if (identical(x, y)) {
+  if (identical(x, y, ignore.srcref = opts$ignore_srcref)) {
     if (is_character(x) && !opts$ignore_encoding) {
       if (identical(Encoding(x), Encoding(y))) {
         return(character())

--- a/R/compare.R
+++ b/R/compare.R
@@ -107,16 +107,9 @@ compare <- function(x, y, ...,
   new_compare(out, max_diffs)
 }
 
-
 compare_structure <- function(x, y, paths = c("x", "y"), opts = compare_opts()) {
-  if (identical(x, y, ignore.srcref = opts$ignore_srcref)) {
-    if (is_character(x) && !opts$ignore_encoding) {
-      if (identical(Encoding(x), Encoding(y))) {
-        return(character())
-      }
-    } else {
-      return(character())
-    }
+  if (is_identical(x, y, opts)) {
+    return(character())
   }
 
   # Compare type
@@ -247,6 +240,22 @@ compare_structure <- function(x, y, paths = c("x", "y"), opts = compare_opts()) 
   }
 
   out
+}
+
+# Fast path for "identical" elements - in the long run we'd eliminate this
+# by re-writing all of waldo in C, but this gives us a nice performance boost
+# with for a relatively low cost in the meantime.
+is_identical <- function(x, y, opts) {
+  # These comparisons aren't 100% correct because they don't affect comparison
+  # of character vectors/functions further down the tree. But I think that's
+  # unlikely to have an impact in practice since they're opt-in.
+  if (is_character(x) && is_character(y) && !opts$ignore_encoding) {
+    identical(x, y) && identical(Encoding(x), Encoding(y))
+  } else if (is_function(x) && is_function(y) && !opts$ignore_srcref) {
+    identical(x, y) && identical(attr(x, "srcref"), attr(y, "srcref"))
+  } else {
+    identical(x, y)
+  }
 }
 
 compare_terminate <- function(x, y, paths,

--- a/R/compare.R
+++ b/R/compare.R
@@ -109,8 +109,14 @@ compare <- function(x, y, ...,
 
 
 compare_structure <- function(x, y, paths = c("x", "y"), opts = compare_opts()) {
-  if (is_reference(x, y)) {
-    return(character())
+  if (identical(x, y)) {
+    if (is_character(x) && !opts$ignore_encoding) {
+      if (identical(Encoding(x), Encoding(y))) {
+        return(character())
+      }
+    } else {
+      return(character())
+    }
   }
 
   # Compare type

--- a/tests/testthat/_snaps/compare.md
+++ b/tests/testthat/_snaps/compare.md
@@ -168,3 +168,17 @@
       [25] "y" - "Y" [25]
       [26] "z" - "Z" [26]
 
+# can choose to compare srcrefs
+
+    Code
+      f1 <- f2 <- (function() { })
+      attr(f2, "srcref") <- "{  }"
+      compare(f2, f1)
+    Output
+      v No differences
+    Code
+      compare(f2, f1, ignore_srcref = FALSE)
+    Output
+      `attr(old, 'srcref')` is a character vector ('{  }')
+      `attr(new, 'srcref')` is an S3 object of class <srcref>, an integer vector
+

--- a/tests/testthat/test-compare.R
+++ b/tests/testthat/test-compare.R
@@ -157,6 +157,16 @@ test_that("comparing functions gives useful diffs", {
   })
 })
 
+test_that("can choose to compare srcrefs", {
+  expect_snapshot({
+    f1 <- f2 <- function() {}
+    attr(f2, "srcref") <- "{  }"
+
+    compare(f2, f1)
+    compare(f2, f1, ignore_srcref = FALSE)
+  })
+})
+
 test_that("can compare atomic vectors", {
   verify_output(test_path("test-compare-atomic.txt"), {
     compare(1:3, 10L + 1:3)


### PR DESCRIPTION
Fixes #86

This radically improves performance (I suspect generally making it generally faster than `all.equal()` in the no difference case), particularly for the motivating example, which previously took 2s on my machine:

``` r
library(sf)
#> Linking to GEOS 3.8.1, GDAL 3.1.4, PROJ 6.3.1

sf_points <- do.call(st_sfc, lapply(1:1000, function(x) st_point(runif(2))))
sf_points_copy <- st_as_sfc(st_as_binary(sf_points))

bench::mark(
  waldo::compare(sf_points_copy, sf_points),
  all.equal(sf_points_copy, sf_points),
  identical(sf_points_copy, sf_points),
  check = FALSE
)
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 3 x 6
#>   expression                                     min  median `itr/sec` mem_alloc
#>   <bch:expr>                                <bch:tm> <bch:t>     <dbl> <bch:byt>
#> 1 waldo::compare(sf_points_copy, sf_points)   85.6µs  93.6µs    9315.      503KB
#> 2 all.equal(sf_points_copy, sf_points)        92.1ms  99.4ms      10.1     219KB
#> 3 identical(sf_points_copy, sf_points)        53.4µs  55.7µs   16751.         0B
#> # … with 1 more variable: gc/sec <dbl>
```

<sup>Created on 2021-07-11 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>

However, I need to think if there are edge cases (apart from `Encoding()`) where `identical()` returns `TRUE` and there are actually important differences.