### PR TITLE
Row by row diffs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
 # waldo (development version)
 
-* `compare()` gains a basic row-by-row diff for data frames that is shown when 
-  the values within a data frame are different (#78).
+* `compare()` gains a basic row-by-row diff for data frames (#78) that is shown 
+  when the values within a data frame are different, and for numeric matrices
+  (#76).
 
 * `compare()` automatically uses an elementwise comparison if it's shorter than
   a "smart" diff. This makes it more obvious when you're comparing unrelated 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # waldo (development version)
 
+* `compare()` gains a basic row-by-row diff for data frames that is shown when 
+  the values within a data frame are different (#78).
+
 * `compare()` automatically uses an elementwise comparison if it's shorter than
   a "smart" diff. This makes it more obvious when you're comparing unrelated 
   vectors (#68).

--- a/R/compare-data-frame.R
+++ b/R/compare-data-frame.R
@@ -37,12 +37,18 @@ format_cols <- function(x, y) {
     return()
   }
 
-  # Combine together to match widths
-  cols <- lapply(seq_along(x), function(j) c(x[[j]], y[[j]]))
-  cols <- as.data.frame(cols)
-  names(cols) <- names(x)
+  printed_lines(as.data.frame(x), as.data.frame(y), row.names = FALSE)
+}
 
-  lines <- utils::capture.output(print(cols, row.names = FALSE, width = 500))
+# join together two rectangles then print - this takes advantage of all the
+# logic built into base R to get nice printing
+printed_lines <- function(x, y, ...) {
+  joint <- rbind(x, y)
+  if (!is.data.frame(joint)) {
+    rownames(joint) <- rep("", nrow(joint))
+  }
+  lines <- utils::capture.output(print(joint, ..., width = 500))
+
   row_idx <- c(seq_len(nrow(x)), seq_len(nrow(y)))
   names(lines) <- format(c("", paste0("[", row_idx, ", ]")), align = "right")
 

--- a/R/compare-data-frame.R
+++ b/R/compare-data-frame.R
@@ -1,0 +1,46 @@
+#' @examples
+#'
+#' iris2<- iris
+#' iris2[3,2] <- 17
+#' iris2[3,5] <- "versicolor"
+#' compare(iris, iris2)
+#'
+#' iris2 <- iris
+#' iris2$Species <- as.character(iris$Species)
+#' compare(iris, iris2)
+
+compare_data_frame <- function(x, y, paths = c("x", "y"), opts = compare_opts()) {
+  if (same_cols(x, y)) {
+    x_view <- capture.output(print(as.data.frame(x)))
+    y_view <- capture.output(print(as.data.frame(y)))
+
+    diff_element(x_view, y_view, paths, quote = "", max_diffs = opts$max_diffs)
+  } else {
+    ignore_names <- isTRUE(opts$ignore_attr) || "names" %in% opts$ignore_attr
+    if (!ignore_names) {
+      compare_by_name(x, y, paths, opts)
+    } else {
+      compare_by_pos(x, y, paths, opts)
+    }
+  }
+}
+
+same_cols <- function(x, y) {
+  if (!identical(names(x), names(y))) {
+    return(FALSE)
+  }
+
+  # Implies same column types
+  for (i in seq_along(x)) {
+    if (!identical(typeof(x[[i]]), typeof(y[[i]]))) {
+      return(FALSE)
+    }
+
+    if (!identical(attributes(x[[i]]), attributes(y[[i]]))) {
+      return(FALSE)
+    }
+  }
+
+  TRUE
+}
+

--- a/R/compare-data-frame.R
+++ b/R/compare-data-frame.R
@@ -42,9 +42,12 @@ format_cols <- function(x, y) {
   cols <- as.data.frame(cols)
   names(cols) <- names(x)
 
-  lines <- utils::capture.output(print(cols, row.names = FALSE))
+  lines <- utils::capture.output(print(cols, row.names = FALSE, width = 500))
+  row_idx <- c(seq_len(nrow(x)), seq_len(nrow(y)))
+  names(lines) <- format(c("", paste0("[", row_idx, ", ]")), align = "right")
+
   list(
-    header = lines[[1]],
+    header = lines[1],
     x = lines[2:(nrow(x) + 1)],
     y = lines[(nrow(x) + 2):length(lines)]
   )

--- a/R/compare-data-frame.R
+++ b/R/compare-data-frame.R
@@ -1,8 +1,3 @@
-#' @examples
-#' iris2<- iris
-#' iris2[3,2] <- 17
-#' iris2[3,5] <- "versicolor"
-#' compare(iris, iris2)
 compare_data_frame <- function(x, y, paths = c("x", "y"), opts = compare_opts()) {
   # Only show row diffs if columns are the same and there are rows
   if (!same_cols(x, y)) {

--- a/R/compare-data-frame.R
+++ b/R/compare-data-frame.R
@@ -7,7 +7,7 @@ compare_data_frame <- function(x, y, paths = c("x", "y"), opts = compare_opts())
     return()
   }
 
-  rows <- df_rows(x, y)
+  rows <- df_rows(x, y, paths = paths)
   if (is.null(rows)) {
     return()
   }
@@ -33,7 +33,7 @@ diff_rows <- function(rows, paths = c("x", "y"), max_diffs = 10) {
 }
 
 # Make a character matrix of formatted cell values
-df_rows <- function(x, y) {
+df_rows <- function(x, y, paths = c("x", "y")) {
   x <- factor_to_char(x)
   y <- factor_to_char(y)
 
@@ -47,12 +47,12 @@ df_rows <- function(x, y) {
     return()
   }
 
-  printed_rows(as.data.frame(x), as.data.frame(y), row.names = FALSE)
+  printed_rows(as.data.frame(x), as.data.frame(y), row.names = FALSE, paths = paths)
 }
 
 # join together two rectangles then print - this takes advantage of all the
 # logic built into base R to get nice printing
-printed_rows <- function(x, y, ...) {
+printed_rows <- function(x, y, ..., paths = c("x", "y")) {
   joint <- rbind(x, y)
   if (!is.data.frame(joint)) {
     rownames(joint) <- rep("", nrow(joint))
@@ -60,7 +60,8 @@ printed_rows <- function(x, y, ...) {
   lines <- utils::capture.output(print(joint, ..., width = 500))
 
   row_idx <- c(seq_len(nrow(x)), seq_len(nrow(y)))
-  names(lines) <- format(c("", paste0("[", row_idx, ", ]")), align = "right")
+  row_idx <- paste0(rep(paths, c(nrow(x), nrow(y))), "[", row_idx, ", ]")
+  names(lines) <- format(c("", row_idx), align = "right")
 
   list(
     header = lines[1],

--- a/R/compare-value.R
+++ b/R/compare-value.R
@@ -24,7 +24,7 @@ compare_numeric <- function(x, y, paths = c("x", "y"), tolerance = default_tol()
   }
 
   if (!is.null(dim(x)) && identical(dim(x), dim(y))) {
-    rows <- printed_rows(x, y)
+    rows <- printed_rows(x, y, paths = paths)
     out <- diff_rows(rows, paths = paths, max_diffs = max_diffs)
 
     if (length(out) > 0) {

--- a/R/compare-value.R
+++ b/R/compare-value.R
@@ -64,6 +64,9 @@ num_exact <- function(x, digits = 6) {
 
 # Minimal number of digits needed to show differences
 min_digits <- function(x, y) {
+  attributes(x) <- NULL
+  attributes(y) <- NULL
+
   digits(abs(x - y))
 }
 

--- a/R/compare-value.R
+++ b/R/compare-value.R
@@ -24,8 +24,8 @@ compare_numeric <- function(x, y, paths = c("x", "y"), tolerance = default_tol()
   }
 
   if (!is.null(dim(x)) && identical(dim(x), dim(y))) {
-    lines <- printed_lines(x, y)
-    out <- diff_rows(lines$x, lines$y, lines$header, paths = paths, max_diffs = max_diffs)
+    rows <- printed_rows(x, y)
+    out <- diff_rows(rows, paths = paths, max_diffs = max_diffs)
 
     if (length(out) > 0) {
       return(out)

--- a/R/compare-value.R
+++ b/R/compare-value.R
@@ -23,6 +23,15 @@ compare_numeric <- function(x, y, paths = c("x", "y"), tolerance = default_tol()
     return(new_compare())
   }
 
+  if (!is.null(dim(x)) && identical(dim(x), dim(y))) {
+    lines <- printed_lines(x, y)
+    out <- diff_rows(lines$x, lines$y, lines$header, paths = paths, max_diffs = max_diffs)
+
+    if (length(out) > 0) {
+      return(out)
+    }
+  }
+
   if (length(x) == length(y)) {
     digits <- min_digits(x, y)
     x_fmt <- num_exact(x, digits = digits)
@@ -39,6 +48,7 @@ compare_numeric <- function(x, y, paths = c("x", "y"), tolerance = default_tol()
     justify = "right",
     max_diffs = max_diffs
   )
+
   if (length(out) > 0) {
     out
   } else {

--- a/R/compare.R
+++ b/R/compare.R
@@ -161,9 +161,11 @@ compare_structure <- function(x, y, paths = c("x", "y"), opts = compare_opts()) 
   }
 
   # Then contents
-  if (is.data.frame(x)) {
-    out <- c(out, compare_data_frame(x, y, paths, opts = opts))
-  } else if (is_list(x) || is_pairlist(x) || is.expression(x)) {
+  if (is_list(x) || is_pairlist(x) || is.expression(x)) {
+    if (is.data.frame(x)) {
+      out <- c(out, compare_data_frame(x, y, paths, opts = opts))
+    }
+
     x <- unclass(x)
     y <- unclass(y)
 
@@ -173,6 +175,7 @@ compare_structure <- function(x, y, paths = c("x", "y"), opts = compare_opts()) 
     } else {
       out <- c(out, compare_by_pos(x, y, paths, opts))
     }
+
   } else if (is_environment(x)) {
     if (env_has(x, ".__enclos_env__")) {
       # enclosing env of methods is object env
@@ -350,9 +353,6 @@ compare_by_pos <- compare_by(index_pos, extract_pos, path_pos)
 
 path_line <- function(path, i) glue("lines({path}[[{i}]])")
 compare_by_line <- compare_by(index_pos, extract_pos, path_line)
-
-path_row <- function(path, i) glue("{path}[{i},]")
-compare_by_row <- compare_by(index_pos, extract_pos, path_row)
 
 path_attr <- function(path, i) {
   # from ?attributes, excluding row.names() because it's not a simple accessor

--- a/R/compare.R
+++ b/R/compare.R
@@ -161,7 +161,9 @@ compare_structure <- function(x, y, paths = c("x", "y"), opts = compare_opts()) 
   }
 
   # Then contents
-  if (is_list(x) || is_pairlist(x) || is.expression(x)) {
+  if (is.data.frame(x)) {
+    out <- c(out, compare_data_frame(x, y, paths, opts = opts))
+  } else if (is_list(x) || is_pairlist(x) || is.expression(x)) {
     x <- unclass(x)
     y <- unclass(y)
 
@@ -348,6 +350,9 @@ compare_by_pos <- compare_by(index_pos, extract_pos, path_pos)
 
 path_line <- function(path, i) glue("lines({path}[[{i}]])")
 compare_by_line <- compare_by(index_pos, extract_pos, path_line)
+
+path_row <- function(path, i) glue("{path}[{i},]")
+compare_by_row <- compare_by(index_pos, extract_pos, path_row)
 
 path_attr <- function(path, i) {
   # from ?attributes, excluding row.names() because it's not a simple accessor

--- a/R/compare.R
+++ b/R/compare.R
@@ -226,8 +226,6 @@ compare_structure <- function(x, y, paths = c("x", "y"), opts = compare_opts()) 
         max_diffs = opts$max_diffs
       ))
     }
-    attributes(x) <- NULL
-    attributes(y) <- NULL
 
     out <- c(out, switch(typeof(x),
       integer = ,

--- a/R/diff.R
+++ b/R/diff.R
@@ -107,25 +107,6 @@ diff_element <- function(x, y, paths = c("x", "y"),
   new_compare(unlist(format, recursive = FALSE))
 }
 
-
-diff_rows <- function(x, y, header, paths = c("x", "y"), max_diffs = 10) {
-  diffs <- ses_shortest(x, y)
-  if (length(diffs) == 0) {
-    return(new_compare())
-  }
-
-  # Align with diffs
-  header <- paste0("  ", names(header), cli::style_bold(header))
-
-  format <- lapply(diffs, function(diff) {
-    path_label <- paste0(paths[[1]], " vs ", paths[[2]])
-
-    lines <- line_by_line(x, y, diff, max_diffs = max_diffs)
-    paste0(c(path_label, header, lines), collapse = "\n")
-  })
-  new_compare(unlist(format, recursive = FALSE))
-}
-
 format_diff_matrix <- function(diff, x, y, paths,
                                justify = "left",
                                width = getOption("width"),

--- a/R/diff.R
+++ b/R/diff.R
@@ -115,10 +115,11 @@ diff_rows <- function(x, y, header, paths = c("x", "y"), max_diffs = 10) {
   }
 
   # Align with diffs
-  header <- paste(" ", header)
+  header <- paste0("  ", names(header), cli::style_bold(header))
 
   format <- lapply(diffs, function(diff) {
     path_label <- paste0(paths[[1]], " vs ", paths[[2]])
+
     lines <- line_by_line(x, y, diff, max_diffs = max_diffs)
     paste0(c(path_label, header, lines), collapse = "\n")
   })
@@ -191,9 +192,9 @@ format_diff_matrix <- function(diff, x, y, paths,
 line_by_line <- function(x, y, diff, max_diffs = 10) {
   lines <- character()
 
-  line_a <- function(x) if (length(x) > 0) col_a(paste0("+ ", x))
-  line_d <- function(x) if (length(x) > 0) col_d(paste0("- ", x))
-  line_x <- function(x) if (length(x) > 0) col_x(paste0("  ", x))
+  line_a <- function(x) if (length(x) > 0) col_a(paste0("+ ", names(x), x))
+  line_d <- function(x) if (length(x) > 0) col_d(paste0("- ", names(x), x))
+  line_x <- function(x) if (length(x) > 0) col_x(paste0("  ", names(x), x))
 
   n <- min(max_diffs, nrow(diff))
   n_trunc <- nrow(diff) - n

--- a/R/num_equal.R
+++ b/R/num_equal.R
@@ -7,6 +7,9 @@ num_equal <- function(x, y, tolerance = .Machine$double.eps ^ 0.5) {
     return(FALSE)
   }
 
+  attributes(x) <- NULL
+  attributes(y) <- NULL
+
   same <- is.na(x) | x == y
   if (is.null(tolerance)) {
     return(all(same))

--- a/tests/testthat/_snaps/compare-data-frame.md
+++ b/tests/testthat/_snaps/compare-data-frame.md
@@ -7,12 +7,12 @@
       `attr(new, 'row.names')`: 1 2 3    
       
       old vs new
-         x y
-         1 5
-         2 4
-         3 3
-      -  4 2
-      -  5 1
+              x y
+        [1, ] 1 5
+        [2, ] 2 4
+        [3, ] 3 3
+      - [4, ] 4 2
+      - [5, ] 5 1
       
       `old$x`: 1 2 3 4 5
       `new$x`: 1 2 3    
@@ -26,12 +26,12 @@
       `attr(new, 'row.names')[3:6]`: 3 4 5 6
       
       old vs new
-         x y
-         1 5
-      +  5 1
-         2 4
-         3 3
-         4 2
+              x y
+        [1, ] 1 5
+      + [2, ] 5 1
+        [2, ] 2 4
+        [3, ] 3 3
+        [4, ] 4 2
       
       `old$x[1:4]`: 1   2 3 4
       `new$x[1:5]`: 1 5 2 3 4
@@ -45,11 +45,11 @@
       compare(df1, df2)
     Output
       old vs new
-           x z
-           1 a
-      -    2 b
-      +  100 B
-           3 c
+                x z
+        [1, ]   1 a
+      - [2, ]   2 b
+      + [2, ] 100 B
+        [3, ]   3 c
       
       `old$x` is an integer vector (1, 2, 3)
       `new$x` is a double vector (1, 100, 3)

--- a/tests/testthat/_snaps/compare-data-frame.md
+++ b/tests/testthat/_snaps/compare-data-frame.md
@@ -1,0 +1,67 @@
+# informative diff for additions and deletions
+
+    Code
+      compare(df, unrowname(df[1:3, ]))
+    Output
+      `attr(old, 'row.names')`: 1 2 3 4 5
+      `attr(new, 'row.names')`: 1 2 3    
+      
+      old vs new
+         x y
+         1 5
+         2 4
+         3 3
+      -  4 2
+      -  5 1
+      
+      `old$x`: 1 2 3 4 5
+      `new$x`: 1 2 3    
+      
+      `old$y`: 5 4 3 2 1
+      `new$y`: 5 4 3    
+    Code
+      compare(df, unrowname(df[c(1, 5, 2, 3, 4, 5), ]))
+    Output
+      `attr(old, 'row.names')[3:5]`: 3 4 5  
+      `attr(new, 'row.names')[3:6]`: 3 4 5 6
+      
+      old vs new
+         x y
+         1 5
+      +  5 1
+         2 4
+         3 3
+         4 2
+      
+      `old$x[1:4]`: 1   2 3 4
+      `new$x[1:5]`: 1 5 2 3 4
+      
+      `old$y[1:4]`: 5   4 3 2
+      `new$y[1:5]`: 5 1 4 3 2
+
+# informative diff for changes
+
+    Code
+      compare(df1, df2)
+    Output
+      old vs new
+           x z
+           1 a
+      -    2 b
+      +  100 B
+           3 c
+      
+      `old$x` is an integer vector (1, 2, 3)
+      `new$x` is a double vector (1, 100, 3)
+      
+      `old$z`: "a" "b" "c"
+      `new$z`: "a" "B" "c"
+
+# converts factors to strings
+
+    Code
+      compare(df1, df2)
+    Output
+      `levels(old$x)`: "a" "b" "c"
+      `levels(new$x)`: "a" "b" "d"
+

--- a/tests/testthat/_snaps/compare-data-frame.md
+++ b/tests/testthat/_snaps/compare-data-frame.md
@@ -43,8 +43,9 @@
 # informative diff for changes
 
     Code
-      df1 <- data.frame(x = 1:3, y = 1, z = c("a", "b", "c"))
-      df2 <- data.frame(x = c(1, 100, 3), y = 1, z = c("a", "B", "c"))
+      df1 <- data.frame(x = 1:3, y = 1, z = c("a", "b", "c"), stringsAsFactors = FALSE)
+      df2 <- data.frame(x = c(1, 100, 3), y = 1, z = c("a", "B", "c"),
+      stringsAsFactors = FALSE)
       compare(df1, df2)
     Output
       old vs new

--- a/tests/testthat/_snaps/compare-data-frame.md
+++ b/tests/testthat/_snaps/compare-data-frame.md
@@ -8,12 +8,12 @@
       `attr(new, 'row.names')`: 1 2 3    
       
       old vs new
-              x y
-        [1, ] 1 5
-        [2, ] 2 4
-        [3, ] 3 3
-      - [4, ] 4 2
-      - [5, ] 5 1
+                 x y
+        old[1, ] 1 5
+        old[2, ] 2 4
+        old[3, ] 3 3
+      - old[4, ] 4 2
+      - old[5, ] 5 1
       
       `old$x`: 1 2 3 4 5
       `new$x`: 1 2 3    
@@ -27,12 +27,12 @@
       `attr(new, 'row.names')[3:6]`: 3 4 5 6
       
       old vs new
-              x y
-        [1, ] 1 5
-      + [2, ] 5 1
-        [2, ] 2 4
-        [3, ] 3 3
-        [4, ] 4 2
+                 x y
+        old[1, ] 1 5
+      + new[2, ] 5 1
+        old[2, ] 2 4
+        old[3, ] 3 3
+        old[4, ] 4 2
       
       `old$x[1:4]`: 1   2 3 4
       `new$x[1:5]`: 1 5 2 3 4
@@ -48,11 +48,11 @@
       compare(df1, df2)
     Output
       old vs new
-                x z
-        [1, ]   1 a
-      - [2, ]   2 b
-      + [2, ] 100 B
-        [3, ]   3 c
+                   x z
+        old[1, ]   1 a
+      - old[2, ]   2 b
+      + new[2, ] 100 B
+        old[3, ]   3 c
       
       `old$x` is an integer vector (1, 2, 3)
       `new$x` is a double vector (1, 100, 3)

--- a/tests/testthat/_snaps/compare-data-frame.md
+++ b/tests/testthat/_snaps/compare-data-frame.md
@@ -1,6 +1,7 @@
 # informative diff for additions and deletions
 
     Code
+      df <- data.frame(x = 1:5, y = 5:1)
       compare(df, unrowname(df[1:3, ]))
     Output
       `attr(old, 'row.names')`: 1 2 3 4 5
@@ -42,6 +43,8 @@
 # informative diff for changes
 
     Code
+      df1 <- data.frame(x = 1:3, y = 1, z = c("a", "b", "c"))
+      df2 <- data.frame(x = c(1, 100, 3), y = 1, z = c("a", "B", "c"))
       compare(df1, df2)
     Output
       old vs new

--- a/tests/testthat/_snaps/compare-value.md
+++ b/tests/testthat/_snaps/compare-value.md
@@ -187,12 +187,21 @@
 # numeric comparison works on factors
 
     Code
-      x <- factor(c("a", "b", "c"), c("a", "b", "c"))
-      y <- factor(c("a", "c", "b"), c("a", "c", "b"))
-      compare(x, y)
+      f1 <- factor(c("a", "b", "c"))
+      f2 <- factor(c("a", "c", "b"), c("a", "c", "b"))
+      compare(f1, f2)
     Output
       `levels(old)`: "a" "b" "c"
       `levels(new)`: "a" "c" "b"
+    Code
+      f3 <- factor(c("a", "B", "c"))
+      compare(f1, f3)
+    Output
+      `levels(old)`: "a" "b" "c"
+      `levels(new)`: "B" "a" "c"
+      
+      `old`: 1 2 3
+      `new`: 2 1 3
 
 # shows row-by-row diff for numeric matrices
 

--- a/tests/testthat/_snaps/compare-value.md
+++ b/tests/testthat/_snaps/compare-value.md
@@ -184,6 +184,16 @@
       `x[2:3]`: 2             
            `y`: 1 2.0000001  3
 
+# numeric comparison works on factors
+
+    Code
+      x <- factor(c("a", "b", "c"), c("a", "b", "c"))
+      y <- factor(c("a", "c", "b"), c("a", "c", "b"))
+      compare(x, y)
+    Output
+      `levels(old)`: "a" "b" "c"
+      `levels(new)`: "a" "c" "b"
+
 # logical comparisons minimise extraneous diffs
 
     Code

--- a/tests/testthat/_snaps/compare-value.md
+++ b/tests/testthat/_snaps/compare-value.md
@@ -211,10 +211,10 @@
       compare(x, y)
     Output
       old vs new
-              [,1] [,2]
-        [1, ]    1    3
-      - [2, ]    2    4
-      + [2, ]    2    5
+                 [,1] [,2]
+        old[1, ]    1    3
+      - old[2, ]    2    4
+      + new[2, ]    2    5
 
 # falls back to regular display if printed representation the same
 

--- a/tests/testthat/_snaps/compare-value.md
+++ b/tests/testthat/_snaps/compare-value.md
@@ -194,6 +194,29 @@
       `levels(old)`: "a" "b" "c"
       `levels(new)`: "a" "c" "b"
 
+# shows row-by-row diff for numeric matrices
+
+    Code
+      x <- y <- matrix(1:4, nrow = 2)
+      y[2, 2] <- 5L
+      compare(x, y)
+    Output
+      old vs new
+              [,1] [,2]
+        [1, ]    1    3
+      - [2, ]    2    4
+      + [2, ]    2    5
+
+# falls back to regular display if printed representation the same
+
+    Code
+      x <- y <- matrix(1:4, nrow = 2)
+      y[2, 2] <- y[2, 2] + 1e-10
+      compare(x, y)
+    Output
+      `old` is an integer vector (1, 2, 3, 4)
+      `new` is a double vector (1, 2, 3, 4.0000000001)
+
 # logical comparisons minimise extraneous diffs
 
     Code

--- a/tests/testthat/test-compare-data-frame.R
+++ b/tests/testthat/test-compare-data-frame.R
@@ -1,17 +1,15 @@
 test_that("informative diff for additions and deletions", {
-  df <- data.frame(x = 1:5, y = 5:1)
-
   expect_snapshot({
+    df <- data.frame(x = 1:5, y = 5:1)
     compare(df, unrowname(df[1:3, ]))
     compare(df, unrowname(df[c(1, 5, 2, 3, 4, 5), ]))
   })
 })
 
 test_that("informative diff for changes", {
-  df1 <- data.frame(x = 1:3, y = 1, z = c("a", "b", "c"))
-  df2 <- data.frame(x = c(1, 100, 3), y = 1, z = c("a", "B", "c"))
-
   expect_snapshot({
+    df1 <- data.frame(x = 1:3, y = 1, z = c("a", "b", "c"))
+    df2 <- data.frame(x = c(1, 100, 3), y = 1, z = c("a", "B", "c"))
     compare(df1, df2)
   })
 })

--- a/tests/testthat/test-compare-data-frame.R
+++ b/tests/testthat/test-compare-data-frame.R
@@ -1,0 +1,38 @@
+test_that("informative diff for additions and deletions", {
+  df <- data.frame(x = 1:5, y = 5:1)
+
+  expect_snapshot({
+    compare(df, unrowname(df[1:3, ]))
+    compare(df, unrowname(df[c(1, 5, 2, 3, 4, 5), ]))
+  })
+})
+
+test_that("informative diff for changes", {
+  df1 <- data.frame(x = 1:3, y = 1, z = c("a", "b", "c"))
+  df2 <- data.frame(x = c(1, 100, 3), y = 1, z = c("a", "B", "c"))
+
+  expect_snapshot({
+    compare(df1, df2)
+  })
+})
+
+test_that("converts factors to strings", {
+  df1 <- data.frame(x = factor(c("a", "b", "c")))
+  df2 <- data.frame(x = factor(c("a", "b", "d")))
+
+  expect_snapshot({
+    compare(df1, df2)
+  })
+})
+
+test_that("only used for appropriate data frames", {
+  df <- data.frame(x = 1)
+
+  expect_equal(compare_data_frame(df, df), NULL)
+  expect_equal(compare_data_frame(df, data.frame()), NULL)
+  expect_equal(compare_data_frame(df, data.frame(y = 1)), NULL)
+  expect_equal(compare_data_frame(df, data.frame(x = FALSE)), NULL)
+  expect_equal(compare_data_frame(df, data.frame(x = structure(1, a = 1))), NULL)
+
+  expect_equal(compare_data_frame(data.frame(), data.frame()), NULL)
+})

--- a/tests/testthat/test-compare-data-frame.R
+++ b/tests/testthat/test-compare-data-frame.R
@@ -8,8 +8,8 @@ test_that("informative diff for additions and deletions", {
 
 test_that("informative diff for changes", {
   expect_snapshot({
-    df1 <- data.frame(x = 1:3, y = 1, z = c("a", "b", "c"))
-    df2 <- data.frame(x = c(1, 100, 3), y = 1, z = c("a", "B", "c"))
+    df1 <- data.frame(x = 1:3, y = 1, z = c("a", "b", "c"), stringsAsFactors = FALSE)
+    df2 <- data.frame(x = c(1, 100, 3), y = 1, z = c("a", "B", "c"), stringsAsFactors = FALSE)
     compare(df1, df2)
   })
 })

--- a/tests/testthat/test-compare-value.R
+++ b/tests/testthat/test-compare-value.R
@@ -73,9 +73,12 @@ test_that("numeric comparison", {
 
 test_that("numeric comparison works on factors", {
   expect_snapshot({
-    x <- factor(c("a", "b", "c"), c("a", "b", "c"))
-    y <- factor(c("a", "c", "b"), c("a", "c", "b"))
-    compare(x, y)
+    f1 <- factor(c("a", "b", "c"))
+    f2 <- factor(c("a", "c", "b"), c("a", "c", "b"))
+    compare(f1, f2)
+
+    f3 <- factor(c("a", "B", "c"))
+    compare(f1, f3)
   })
 })
 

--- a/tests/testthat/test-compare-value.R
+++ b/tests/testthat/test-compare-value.R
@@ -79,6 +79,22 @@ test_that("numeric comparison works on factors", {
   })
 })
 
+test_that("shows row-by-row diff for numeric matrices", {
+  expect_snapshot({
+    x <- y <- matrix(1:4, nrow = 2)
+    y[2, 2] <- 5L
+    compare(x, y)
+  })
+})
+
+test_that("falls back to regular display if printed representation the same", {
+  expect_snapshot({
+    x <- y <- matrix(1:4, nrow = 2)
+    y[2, 2] <- y[2, 2] + 1e-10
+    compare(x, y)
+  })
+})
+
 test_that("logical comparisons minimise extraneous diffs", {
   x1 <- x2 <- rep(TRUE, 50)
   x2[c(1, 25, 50)] <- FALSE

--- a/tests/testthat/test-compare-value.R
+++ b/tests/testthat/test-compare-value.R
@@ -71,6 +71,14 @@ test_that("numeric comparison", {
   })
 })
 
+test_that("numeric comparison works on factors", {
+  expect_snapshot({
+    x <- factor(c("a", "b", "c"), c("a", "b", "c"))
+    y <- factor(c("a", "c", "b"), c("a", "c", "b"))
+    compare(x, y)
+  })
+})
+
 test_that("logical comparisons minimise extraneous diffs", {
   x1 <- x2 <- rep(TRUE, 50)
   x2[c(1, 25, 50)] <- FALSE


### PR DESCRIPTION
Uses printed representation of object, so must always be accompanied by fallback

Fixes #76. Fixes #78.