### PR TITLE
Add compare_proxy() to path

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # waldo (development version)
 
+* `compare_proxy()` is now reported in the path (#73).
+
 * `compare()` automatically uses an elementwise comparison if it's shorter than
   a "smart" diff. This makes it more obvious when you're comparing unrelated 
   vectors (#68).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # waldo (development version)
 
-* `compare_proxy()` is now reported in the path (#73).
+* `compare_proxy()` is gains a second argument, `path`, that is used to report
+  how the proxy has been used to change the object. This makes it easier to 
+  see when and how a proxy is involved (#73).
 
 * `compare()` automatically uses an elementwise comparison if it's shorter than
   a "smart" diff. This makes it more obvious when you're comparing unrelated 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # waldo (development version)
 
-* `compare_proxy()` is gains a second argument, `path`, that is used to report
+* `compare_proxy()` gains a second argument, `path`, that is used to report
   how the proxy has been used to change the object. This makes it easier to 
   see when and how a proxy is involved (#73).
 

--- a/R/compare.R
+++ b/R/compare.R
@@ -109,18 +109,14 @@ compare <- function(x, y, ...,
 
 compare_structure <- function(x, y, paths = c("x", "y"), opts = compare_opts()) {
   if (!is_missing(x)) {
-    old <- x
-    x <- compare_proxy(x)
-    if (!is_reference(x, old)) {
-      paths[[1]] <- paste0("compare_proxy(", paths[[1]], ")")
-    }
+    proxy <- compare_proxy(x, paths[[1]])
+    x <- proxy$object
+    paths[[1]] <- proxy$path
   }
   if (!is_missing(y)) {
-    old <- y
-    y <- compare_proxy(y)
-    if (!is_reference(y, old)) {
-      paths[[2]] <- paste0("compare_proxy(", paths[[2]], ")")
-    }
+    proxy <- compare_proxy(y, paths[[2]])
+    y <- proxy$object
+    paths[[2]] <- proxy$path
   }
 
   if (is_identical(x, y, opts)) {

--- a/R/compare.R
+++ b/R/compare.R
@@ -109,10 +109,18 @@ compare <- function(x, y, ...,
 
 compare_structure <- function(x, y, paths = c("x", "y"), opts = compare_opts()) {
   if (!is_missing(x)) {
+    old <- x
     x <- compare_proxy(x)
+    if (!is_reference(x, old)) {
+      paths[[1]] <- paste0("compare_proxy(", paths[[1]], ")")
+    }
   }
   if (!is_missing(y)) {
+    old <- y
     y <- compare_proxy(y)
+    if (!is_reference(y, old)) {
+      paths[[2]] <- paste0("compare_proxy(", paths[[2]], ")")
+    }
   }
 
   if (is_identical(x, y, opts)) {

--- a/R/proxy.R
+++ b/R/proxy.R
@@ -2,10 +2,10 @@
 #'
 #' @description
 #' Use this generic to override waldo's default comparison if you need to
-#' override the defaults (typically because your object contains an external
-#' pointer).
+#' override the defaults (typically because your object stores data in an
+#' external pointer).
 #'
-#' waldo comes with methods for two common cases:
+#' waldo comes with methods for a few common cases:
 #'
 #' * data.table: the `.internal.selfref` attribute is set to `NULL`. This is
 #'   an external pointer that is used for performance optimisation, and
@@ -18,68 +18,52 @@
 #' * Classes from the `RProtoBuf` package: like XML objects, these store
 #'   data in memory in C++ and only expose string names to R. Fortunately,
 #'   these have well-understood string representations that we can use for
-#'   comparsions. See
+#'   comparisons. See
 #'   <https://developers.google.com/protocol-buffers/docs/reference/cpp/google.protobuf.text_format>
 #'
 #' @param x An object.
+#' @param path Path
+#' @return A list with two components:
+#' * `object`: the modified object
+#' * `path`: an updated path showing what modification was applied
 #' @export
-compare_proxy <- function(x) {
+compare_proxy <- function(x, path = "x") {
   UseMethod("compare_proxy")
 }
 
 #' @export
-compare_proxy.default <- function(x) {
-  x
+compare_proxy.default <- function(x, path) {
+  list(object = x, path = path)
 }
 
 #' @export
-compare_proxy.data.table <- function(x) {
+compare_proxy.data.table <- function(x, path) {
   attr(x, ".internal.selfref") <- NULL
-  x
+  list(object = x, path = path)
 }
 
 #' @export
-compare_proxy.xml_node <- function(x) {
-  as.character(x)
+compare_proxy.xml_node <- function(x, path) {
+  list(object = x, path = paste0("as.character(", x, ")"))
 }
 
-# RProtoBuf objects
-#' @export
-compare_proxy.Message <- function(x) {
-  x$toString()
+# RProtoBuf objects -------------------------------------------------------
+compare_protobuf <- function(x, path) {
+  list(object = x$toString, path = paste0(path, "$toString()"))
 }
-
 #' @export
-compare_proxy.Descriptor <- function(x) {
-  x$toString()
-}
-
+compare_proxy.Message <- compare_protobuf
 #' @export
-compare_proxy.EnumDescriptor <- function(x) {
-  x$toString()
-}
-
+compare_proxy.Descriptor <- compare_protobuf
 #' @export
-compare_proxy.FieldDescriptor <- function(x) {
-  x$toString()
-}
-
+compare_proxy.EnumDescriptor <- compare_protobuf
 #' @export
-compare_proxy.ServiceDescriptor <- function(x) {
-  x$toString()
-}
-
+compare_proxy.FieldDescriptor <- compare_protobuf
 #' @export
-compare_proxy.FileDescriptor <- function(x) {
-  x$toString()
-}
-
+compare_proxy.ServiceDescriptor <- compare_protobuf
 #' @export
-compare_proxy.EnumValueDescriptor <- function(x) {
-  x$toString()
-}
-
+compare_proxy.FileDescriptor <- compare_protobuf
 #' @export
-compare_proxy.MethodDescriptor <- function(x) {
-  x$toString()
-}
+compare_proxy.EnumValueDescriptor <- compare_protobuf
+#' @export
+compare_proxy.MethodDescriptor <- compare_protobuf

--- a/man/compare_proxy.Rd
+++ b/man/compare_proxy.Rd
@@ -4,17 +4,26 @@
 \alias{compare_proxy}
 \title{Proxy for waldo comparison}
 \usage{
-compare_proxy(x)
+compare_proxy(x, path = "x")
 }
 \arguments{
 \item{x}{An object.}
+
+\item{path}{Path}
+}
+\value{
+A list with two components:
+\itemize{
+\item \code{object}: the modified object
+\item \code{path}: an updated path showing what modification was applied
+}
 }
 \description{
 Use this generic to override waldo's default comparison if you need to
-override the defaults (typically because your object contains an external
-pointer).
+override the defaults (typically because your object stores data in an
+external pointer).
 
-waldo comes with methods for two common cases:
+waldo comes with methods for a few common cases:
 \itemize{
 \item data.table: the \code{.internal.selfref} attribute is set to \code{NULL}. This is
 an external pointer that is used for performance optimisation, and
@@ -25,7 +34,7 @@ object to a string.
 \item Classes from the \code{RProtoBuf} package: like XML objects, these store
 data in memory in C++ and only expose string names to R. Fortunately,
 these have well-understood string representations that we can use for
-comparsions. See
+comparisons. See
 \url{https://developers.google.com/protocol-buffers/docs/reference/cpp/google.protobuf.text_format}
 }
 }

--- a/tests/testthat/_snaps/compare.md
+++ b/tests/testthat/_snaps/compare.md
@@ -558,3 +558,11 @@
       `old[[3]]`: `a + b`
       `new[[3]]`: `a + c`
 
+# compare_proxy() modifies path
+
+    Code
+      compare(foo1, foo2)
+    Output
+      `compare_proxy(old)$x`: 1
+      `compare_proxy(new)$x`: 2
+

--- a/tests/testthat/_snaps/compare.md
+++ b/tests/testthat/_snaps/compare.md
@@ -563,6 +563,6 @@
     Code
       compare(foo1, foo2)
     Output
-      `compare_proxy(old)$x`: 1
-      `compare_proxy(new)$x`: 2
+      `proxy(old)$x`: 1
+      `proxy(new)$x`: 2
 

--- a/tests/testthat/test-compare.R
+++ b/tests/testthat/test-compare.R
@@ -264,7 +264,9 @@ test_that("comparing language objects gives useful diffs", {
 
 test_that("compare_proxy() can change type", {
   local_bindings(
-    compare_proxy.foo = function(x) 10,
+    compare_proxy.foo = function(x, path) {
+      list(object = 10, path = paste0("proxy(", path, ")"))
+    },
     .env =  global_env()
   )
   expect_equal(
@@ -275,7 +277,9 @@ test_that("compare_proxy() can change type", {
 
 test_that("compare_proxy() modifies path", {
   local_bindings(
-    compare_proxy.foo = function(x) list(x = x$x),
+    compare_proxy.foo = function(x, path) {
+      list(object = list(x = x$x), path = paste0("proxy(", path, ")"))
+    },
     .env =  global_env()
   )
 

--- a/tests/testthat/test-compare.R
+++ b/tests/testthat/test-compare.R
@@ -272,3 +272,14 @@ test_that("compare_proxy() can change type", {
     new_compare()
   )
 })
+
+test_that("compare_proxy() modifies path", {
+  local_bindings(
+    compare_proxy.foo = function(x) list(x = x$x),
+    .env =  global_env()
+  )
+
+  foo1 <- structure(list(x = 1), class = "foo")
+  foo2 <- structure(list(x = 2), class = "foo")
+  expect_snapshot(compare(foo1, foo2))
+})


### PR DESCRIPTION
Fixes #73

@dmurdoch just occurred to me that the obvious way to report the use of a proxy is in the path. I need to clean up the implementation a little, but what do you think of the results?