### PR TITLE
Tweak interleaving in line-by-line diffs

### DIFF
--- a/R/diff.R
+++ b/R/diff.R
@@ -193,8 +193,13 @@ format_diff_matrix <- function(diff, x, y, paths,
 }
 
 interleave <- function(x, y) {
-  ord <- c(seq_along(x), seq_along(y))
-  c(x, y)[order(ord)]
+  # Only interleave if same number of lines
+  if (length(x) == length(y)) {
+    ord <- c(seq_along(x), seq_along(y))
+    c(x, y)[order(ord)]
+  } else {
+    c(x, y)
+  }
 }
 
 label_path <- function(path, slice) {

--- a/tests/testthat/_snaps/diff.md
+++ b/tests/testthat/_snaps/diff.md
@@ -134,3 +134,51 @@
         "b"
       + "c"
 
+# only interleave if change has equal number of lines
+
+    Code
+      x <- letters
+      diff_element(c(x, 1:2, x), c(x, -(1:2), x), width = 10)
+    Output
+      x[24:31] vs y[24:31]
+        "x"
+        "y"
+        "z"
+      - "1"
+      + "-1"
+      - "2"
+      + "-2"
+        "a"
+        "b"
+        "c"
+    Code
+      diff_element(c(x, 1:3, x), c(x, -(1:2), x), width = 10)
+    Output
+      x[24:32] vs y[24:31]
+        "x"
+        "y"
+        "z"
+      - "1"
+      - "2"
+      - "3"
+      + "-1"
+      + "-2"
+        "a"
+        "b"
+        "c"
+    Code
+      diff_element(c(x, 1:2, x), c(x, -(1:3), x), width = 10)
+    Output
+      x[24:31] vs y[24:32]
+        "x"
+        "y"
+        "z"
+      - "1"
+      - "2"
+      + "-1"
+      + "-2"
+      + "-3"
+        "a"
+        "b"
+        "c"
+

--- a/tests/testthat/test-diff.R
+++ b/tests/testthat/test-diff.R
@@ -46,3 +46,12 @@ test_that("element-wise diffs", {
     diff_element(c(letters, "a", "b"), c(letters, "a", "b", "c"), width = 10)
   })
 })
+
+test_that("only interleave if change has equal number of lines", {
+  expect_snapshot({
+    x <- letters # to anchor diffs
+    diff_element(c(x, 1:2, x), c(x, -(1:2), x), width = 10)
+    diff_element(c(x, 1:3, x), c(x, -(1:2), x), width = 10)
+    diff_element(c(x, 1:2, x), c(x, -(1:3), x), width = 10)
+  })
+})


### PR DESCRIPTION
@gaborcsardi does this seem reasonable to you? I think I previously forgot that a "change" type might have a different number of elements in old and new (i.e. in the diff data I get, a change is automatically combined with an immediately following addition/deletion).