### PR TITLE
Fixes error on `compare(1, Inf, tolerance = 1.e-8)`.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * `compare_proxy()` also ignores the `"index"` attribute for data tables (#107, @krlmlr).
 * `compare_proxy()` methods for `RProtoBuf` objects works again ([#119](https://github.com/r-lib/waldo/issues/119), @MichaelChirico)
+* `compare()`ing infinite values using a tolerance caused an error
+([#122](https://github.com/r-lib/waldo/issues/122), @dmurdoch).
 
 # waldo 0.3.1
 

--- a/R/num_equal.R
+++ b/R/num_equal.R
@@ -23,8 +23,8 @@ num_equal <- function(x, y, tolerance = .Machine$double.eps ^ 0.5) {
   avg_diff <- mean(abs(x_diff - y_diff))
   avg_y <- mean(abs(y_diff))
 
-  # compute relative difference when y is "large"
-  if (avg_y > tolerance) {
+  # compute relative difference when y is "large" but finite
+  if (is.finite(avg_y) && avg_y > tolerance) {
     avg_diff <- avg_diff / avg_y
   }
 

--- a/tests/testthat/test-num_equal.R
+++ b/tests/testthat/test-num_equal.R
@@ -20,3 +20,12 @@ test_that("tolerance works the same way for negative values", {
   expect_equal(num_equal(4, 4 + 2 * .Machine$double.eps ^ 0.5), TRUE)
   expect_equal(num_equal(-4, -4 - 2 * .Machine$double.eps ^ 0.5), TRUE)
 })
+
+test_that("infinite values are handled properly", {
+  expect_equal(num_equal(1, Inf), FALSE)
+  expect_equal(num_equal(1, Inf, tolerance = 1.e-8), FALSE)
+  expect_equal(num_equal(Inf, Inf), TRUE)
+  expect_equal(num_equal(Inf, Inf, tolerance = 1.e-8), TRUE)
+  expect_equal(num_equal(-Inf, Inf), FALSE)
+  expect_equal(num_equal(-Inf, Inf, tolerance = 1.e-8), FALSE)
+})


### PR DESCRIPTION
Fixes  issue #122, errors when comparing infinite values with a tolerance.