### PR TITLE
include is.nan()-comparison in num_equal() + test

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # waldo (development version)
 
+* `compare()` now correctly reports that `NA_real_` and `NaN` are different
+  (@sorhawell, #150).
+
 # waldo 0.4.0
 
 * Atomic S3 classes with format methods now use those methods when 

--- a/R/num_equal.R
+++ b/R/num_equal.R
@@ -6,7 +6,6 @@ num_equal <- function(x, y, tolerance = .Machine$double.eps ^ 0.5) {
   if (any(is.na(x) != is.na(y))) {
     return(FALSE)
   }
-
   if (any(is.nan(x) != is.nan(y))) {
     return(FALSE)
   }

--- a/R/num_equal.R
+++ b/R/num_equal.R
@@ -7,6 +7,10 @@ num_equal <- function(x, y, tolerance = .Machine$double.eps ^ 0.5) {
     return(FALSE)
   }
 
+  if (any(is.nan(x) != is.nan(y))) {
+    return(FALSE)
+  }
+
   attributes(x) <- NULL
   attributes(y) <- NULL
 

--- a/tests/testthat/_snaps/compare-value.md
+++ b/tests/testthat/_snaps/compare-value.md
@@ -205,6 +205,14 @@
       `x[2:3]`: 2             
            `y`: 1 2.0000001  3
 
+# informative difference between NA and NaN
+
+    Code
+      compare_numeric(NA_real_, NaN)
+    Output
+      `x`:  NA
+      `y`: NaN
+
 # numeric comparison works on factors
 
     Code

--- a/tests/testthat/test-compare-value.R
+++ b/tests/testthat/test-compare-value.R
@@ -85,6 +85,10 @@ test_that("numeric comparison", {
   })
 })
 
+test_that("informative difference between NA and NaN", {
+  expect_snapshot(compare_numeric(NA_real_, NaN))
+})
+
 test_that("numeric comparison works on factors", {
   expect_snapshot({
     f1 <- factor(c("a", "b", "c"))

--- a/tests/testthat/test-num_equal.R
+++ b/tests/testthat/test-num_equal.R
@@ -30,8 +30,8 @@ test_that("infinite values are handled properly", {
   expect_equal(num_equal(-Inf, Inf, tolerance = 1.e-8), FALSE)
 })
 
-test_that("NaN is different from NA_real_ if base::is.nan says so", {
-  expect_equal(num_equal(NaN, NA_real_), is.nan(NaN)==is.nan(NA_real_))
-  expect_equal(num_equal(NaN, NaN), TRUE)
-  expect_equal(num_equal(NA_real_, NA_real_), TRUE)
+test_that("NaN is different from NA_real_", {
+  expect_false(num_equal(NaN, NA_real_), FALSE)
+  expect_true(num_equal(NaN, NaN))
+  expect_true(num_equal(NA_real_, NA_real_))
 })

--- a/tests/testthat/test-num_equal.R
+++ b/tests/testthat/test-num_equal.R
@@ -29,3 +29,9 @@ test_that("infinite values are handled properly", {
   expect_equal(num_equal(-Inf, Inf), FALSE)
   expect_equal(num_equal(-Inf, Inf, tolerance = 1.e-8), FALSE)
 })
+
+test_that("NaN is different from NA_real_ if base::is.nan says so", {
+  expect_equal(num_equal(NaN, NA_real_), is.nan(NaN)==is.nan(NA_real_))
+  expect_equal(num_equal(NaN, NaN), TRUE)
+  expect_equal(num_equal(NA_real_, NA_real_), TRUE)
+})


### PR DESCRIPTION
Accordingly to `?is.na`  comparing NA_real_ and NaN is not exactly straight forward. It is stated future CPU-architectures may confound NA_real_ and NaN. 

Accordingly to `?is.nan` `identical()` or equality should not be used to check for `NaN`

Proposed solution is to test if `is.nan(NA_real_) == is.nan(NaN)`
... and as long as this base function can tell the difference, so there is a difference.

Making waldo more strict, will likely require some R packages using testthat to update some tests.

My personal angle on this problem is I use testthat to verify my interface between Rust and R. I test if my mappings are isotone(reversible) in respect to `NaN` and `NA_real_`.

Fixes #150