### PR TITLE
Fix error when comparing equal but not identical S7 objects.

### DIFF
--- a/R/compare.R
+++ b/R/compare.R
@@ -316,8 +316,8 @@ compare_structure <- function(x, y, paths = c("x", "y"), opts = compare_opts()) 
     # Unevaluated dots are unlikely to lead to any significant differences
     # in behaviour (they're usually captured incidentally) so we just
     # ignore
-  } else if (typeof(x) != "S4") {
-    abort(glue("{paths[[1]]}: unsupported type {typeof(x)}"), call = NULL)
+  } else if (!typeof(x) %in% c("S4", "object")) {
+    abort(glue("{paths[[1]]}: unsupported type '{typeof(x)}'"), call = NULL)
   }
 
   out


### PR DESCRIPTION
Beginning in R 4.4.0, `typeof(<S7_object>)` will return `"object"`. This patch enables `testthat::expect_equal(<S7_object_a>, <S7_object_b>)` to succeed for S7 objects that are equal, but not identical.