### PR TITLE
remove rematch2 and tibble deps

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,11 +19,8 @@ Imports:
     diffobj (>= 0.3.4),
     glue,
     methods,
-    rematch2,
-    rlang (>= 1.0.0),
-    tibble
+    rlang (>= 1.0.0)
 Suggests: 
-    covr,
     R6,
     testthat (>= 3.0.0),
     withr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # waldo (development version)
 
-* waldo no longer imports fansi (@olivroy, #192).
+* waldo no longer imports fansi, tibble, and rematch2 (@olivroy, #192, #196).
 
 # waldo 0.5.2
 

--- a/R/rematch.R
+++ b/R/rematch.R
@@ -1,0 +1,26 @@
+# Source copied from rematch2::re_match, but doesn't return tibble.
+re_match <- function(text, pattern, perl = TRUE, ...) {
+  stopifnot(is.character(pattern), length(pattern) == 1, !is.na(pattern))
+  text <- as.character(text)
+  match <- regexpr(pattern, text, perl = perl, ...)
+  start <- as.vector(match)
+  length <- attr(match, "match.length")
+  end <- start + length - 1L
+  matchstr <- substring(text, start, end)
+  matchstr[start == -1] <- NA_character_
+  res <- data.frame(
+    stringsAsFactors = FALSE, .text = text,
+    .match = matchstr
+  )
+  if (!is.null(attr(match, "capture.start"))) {
+    gstart <- attr(match, "capture.start")
+    glength <- attr(match, "capture.length")
+    gend <- gstart + glength - 1L
+    groupstr <- substring(text, gstart, gend)
+    groupstr[gstart == -1] <- NA_character_
+    dim(groupstr) <- dim(gstart)
+    res <- cbind(groupstr, res, stringsAsFactors = FALSE)
+  }
+  names(res) <- c(attr(match, "capture.names"), ".text", ".match")
+  res
+}

--- a/R/ses.R
+++ b/R/ses.R
@@ -16,7 +16,7 @@ ses <- function(x, y) {
   }
 
   out <- diffobj::ses(x, y, warn = FALSE, max.diffs = 100)
-  out <- rematch2::re_match(out, paste0(
+  out <- re_match(out, paste0(
     "(?:(?<x1>\\d+),)?(?<x2>\\d+)",
     "(?<t>[acd])",
     "(?:(?<y1>\\d+),)?(?<y2>\\d+)"
@@ -30,7 +30,7 @@ ses <- function(x, y) {
   out$y1 <- as.integer(out$y1)
   out$y2 <- as.integer(out$y2)
 
-  out
+  as.data.frame(out, stringsAsFactors = FALSE)
 }
 
 ses_elementwise <- function(x, y) {
@@ -146,5 +146,5 @@ diff_complete <- function(diff) {
 }
 
 ses_df <- function(x1, x2, t, y1, y2) {
-  tibble::tibble(x1 = x1, x2 = x2, t = t, y1 = y1, y2 = y2)
+  data.frame(x1 = x1, x2 = x2, t = t, y1 = y1, y2 = y2, stringsAsFactors = FALSE)
 }


### PR DESCRIPTION
This will overall reduce the number of dependencies of testthat by 6 (will no longer import rematch2, tibble, pillar, utf8, vctrs, pkgconfig)