### PR TITLE
Restore batch-only snapshot output

### DIFF
--- a/tests/testthat/_snaps/compare.md
+++ b/tests/testthat/_snaps/compare.md
@@ -737,6 +737,19 @@
       `old[[3]]$x`: 1.0
       `new[[3]]$x`: 3.0
 
+# can compare CHARSXP
+
+    Code
+      compare(char1, char2)
+    Output
+      `old` is CHARSXP: foo
+      `new` is CHARSXP: bar
+    Code
+      compare(char1, "foo")
+    Output
+      `old` is an internal string
+      `new` is a character vector ('foo')
+
 # differences in DOTSXP are ignored
 
     Code


### PR DESCRIPTION
This was dropped in #223. LLM struggles to give a convincing explanation of why GHA passed in the first place (as well as in #225, #226) because the logs are all expired, but anyway this test is tricky because anytime we re-generate snapshots for this file in an interactive session, the outputs for this test will be lost:

https://github.com/r-lib/waldo/blob/d9075e4488a45e4189d79f7847b54fcd94a29fff/tests/testthat/test-compare.R#L459-L460

Maybe a snapshot test for this case is best avoided?